### PR TITLE
Scrobble improvements

### DIFF
--- a/app/src/cmd_play.js
+++ b/app/src/cmd_play.js
@@ -31,6 +31,7 @@ module.exports = function(req, res) {
         lru.track_list.length = 0; // https://stackoverflow.com/questions/1232040/how-do-i-empty-an-array-in-javascript
         var play_time = Math.floor(Date.now() / 1000);
 
+		//BN main_tracks.length is the size of the tracklist array returned by Discogs API
         for (var i = 0; i < main_tracks.length; i++) {
             var t = main_tracks[i];
             if ((t.position === '') || (t.type_ != 'track')) continue;
@@ -46,7 +47,11 @@ module.exports = function(req, res) {
                 trackNumber: t.position
             };
 
-            play_time += parse_duration(t.duration);
+			//BN if discogs has no track length data, make default length 3 minutes.
+            if (parse_duration(t.duration) == 0) {
+				play_time += 180;
+			} else { play_time += parse_duration(t.duration); }
+			
             lru.track_list.push(track_scrobble);
         }
 

--- a/app/src/cmd_play.js
+++ b/app/src/cmd_play.js
@@ -22,7 +22,9 @@ module.exports = function(req, res) {
             }
         };        
 
-        var main_artist = data.artists[0].name;
+		//BN added regex to replace parenthesis from artist names from Discogs like "Elder (2)"
+		//BN https://stackoverflow.com/questions/4292468/javascript-regex-remove-text-between-parentheses added $ for end of line match only.
+        var main_artist = data.artists[0].name.replace(/ *\([^)]*\) *$/g, "");
         var main_album = data.title;
         var main_tracks = data.tracklist;
 

--- a/app/src/cmd_play.js
+++ b/app/src/cmd_play.js
@@ -12,13 +12,14 @@ module.exports = function(req, res) {
 
         // from https://stackoverflow.com/a/17098372/5760
         var parse_duration = function (str) {
-            var parts = str.match(/^(\d*:)?(\d*)$/);
-            if (parts) {
+			var parts = str.match(/^(\d*:)?(\d*)$/);
+            //BN Check for non-blank strings - if blank, default track time is 180 sec
+			if (parts[0] != '') {
                 var min = parseInt(parts[1], 10) || 0;
                 var sec = parseInt(parts[2], 10) || 0;
-                return min * 60 + sec;
+				return min * 60 + sec;
             } else {
-                return 0;
+                return 180;
             }
         };        
 
@@ -47,10 +48,7 @@ module.exports = function(req, res) {
                 trackNumber: t.position
             };
 
-			//BN if discogs has no track length data, make default length 3 minutes.
-            if (parse_duration(t.duration) == 0) {
-				play_time += 180;
-			} else { play_time += parse_duration(t.duration); }
+			play_time += parse_duration(t.duration);
 			
             lru.track_list.push(track_scrobble);
         }

--- a/app/src/lru.js
+++ b/app/src/lru.js
@@ -14,17 +14,36 @@ lru.timestamp = function() {
     return Math.floor(Date.now() / 1000);
 }
 
+//BN modifications so that timestamp of first track submitted is always "now"
 lru.filter = function (cmd) {
     var tracks_to_submit = undefined;
+	//BN new variables
+	var original_timestamp_this_track = 0;
+	var original_timestamp_this_side = 0;	
 
     if (cmd === '*') {
         tracks_to_submit = lru.track_list;
     } else
     if ('ABCD'.indexOf(cmd) >= 0) {
         tracks_to_submit = lru.side(cmd);
+		//BN any scrobble action should scrobble the first track "now"
+		for (var i = 0; i < tracks_to_submit.length; i++) {
+			//BN get original timestamp of side A/B/C/D first track. 
+			original_timestamp_this_track = tracks_to_submit[i].timestamp;
+			//BN first track on side should have current timestamp
+			if (i<1) {
+				original_timestamp_this_side = tracks_to_submit[i].timestamp;
+				tracks_to_submit[i].timestamp = Math.floor(Date.now() / 1000);
+			} else {
+				//all other timestamps should have TIMESTAMP =  NOW + original_timestamp_this_track - original_timestamp_this_side
+				tracks_to_submit[i].timestamp = Math.floor(Date.now() / 1000) + original_timestamp_this_track - original_timestamp_this_side;
+			}
+		} 
     } else {
         var n = parseInt(cmd, 10) || 0;
         n = n % lru.track_list.length;
+		//BN single track scrobble timestamps should be "now"
+		lru.track_list[n].timestamp = Math.floor(Date.now() / 1000);
         tracks_to_submit = lru.track_list[n];
     }
 


### PR DESCRIPTION
Hi, here's a few improvements I made to scrobbling:
- Discogs artist names are stripped of trailing parenthesis for scrobbles (eg, scrobble "Elder" instead of "Elder (2)")
- Any scrobble action timestamp defaults to now (previously, if you'd scrobbled Side B, the first scrobble would be x minutes in the future) 
- If Discogs has no track length data, use 3 minutes. 

I accidentally made a bunch of changes on the master of my fork so I'm trying to submit just a few relevant commits using cherry-pick. Hope it works! 